### PR TITLE
- Bump GNOME runtime version to 42

### DIFF
--- a/io.github.trigg.discover_overlay.yaml
+++ b/io.github.trigg.discover_overlay.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.trigg.discover_overlay
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 command: discover-overlay
 finish-args:


### PR DESCRIPTION
Pros:

- Slightly lighter than v41:

    ```
    $ flatpak remote-ls --runtime flathub --columns=ref,download-size,installed-size | grep org.gnome.Platform/
    runtime/org.gnome.Platform/x86_64/3.38  347,3 MB        958,9 MB
    runtime/org.gnome.Platform/x86_64/41    291,0 MB        769,9 MB
    runtime/org.gnome.Platform/x86_64/42    275,5 MB        751,7 MB
    ```

- More apps using v42 than v41, on Flathub:
 
    ```
    $ flatpak remote-ls --app-runtime=org.gnome.Platform/x86_64/41 flathub | wc -l
    165
    $ flatpak remote-ls --app-runtime=org.gnome.Platform/x86_64/42 flathub | wc -l
    189
    ```